### PR TITLE
Format according to paths vs hosts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,42 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+.DS_Store
+*.swp
+*.orig
+
+# Test binary, build with `go test -c`
+*.test
+
+.idea/
+vendor/
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Ignore executables
+target/
+
+dist/
+
+# Ignore tls cert and key
+private.key
+public.crt
+
+# Ignore VsCode files
+.vscode/
+*.code-workspace
 *~
+.eslintcache
+
 *.cert
 *.key
 *.crt
 *.pem
-.idea
 rmm
 !rmm/
-*.test
-dist/
 testdata*
-*.code-workspace
+examples/

--- a/cmd/rmm/main.go
+++ b/cmd/rmm/main.go
@@ -63,15 +63,13 @@ func main() {
 
 	var source mindmap.InputSource
 
-	if (stat.Mode() & os.ModeCharDevice) == 0 {
+	if fileName != "" {
+		source = mindmap.FileInput{
+			FilePath: fileName,
+		}
+	} else if (stat.Mode() & os.ModeCharDevice) == 0 {
 		source = mindmap.ScannerInput{
 			Scanner: bufio.NewScanner(os.Stdin),
-		}
-	} else {
-		if fileName != "" {
-			source = mindmap.FileInput{
-				FilePath: fileName,
-			}
 		}
 	}
 

--- a/internal/mindmap/mindmap.go
+++ b/internal/mindmap/mindmap.go
@@ -2,6 +2,7 @@ package mindmap
 
 import (
 	"bufio"
+	"net/url"
 	"os"
 	"strings"
 )
@@ -68,6 +69,18 @@ type Domain struct {
 	SubDomains []*Domain
 }
 
+// parseHostname takes a string input representing a URL and returns the hostname and path of the URL.
+func parseHostname(input string) (string, string) {
+	if !strings.HasPrefix(input, "http://") && !strings.HasPrefix(input, "https://") {
+		input = "http://" + input
+	}
+	u, err := url.Parse(input)
+	if err != nil {
+		return "", ""
+	}
+	return u.Host, u.Path
+}
+
 type Node map[string]Node
 
 // CreateMindMap reads lines from the input source and creates a mind map as a map[string]interface{}.
@@ -81,8 +94,8 @@ func CreateMindMap(source InputSource) (Node, error) {
 		if lineRes.Line == "" {
 			continue
 		}
-		domain := lineRes.Line
-		parts := strings.Split(domain, ".") // split domain by dot
+		hostname, _ := parseHostname(lineRes.Line)
+		parts := strings.Split(hostname, ".") // split domain by dot
 		currentNode := root
 		for i := len(parts) - 1; i >= 0; i-- { // iterate over parts in reverse order
 			key := strings.Join(parts[i:], ".") // join parts into key

--- a/internal/mindmap/mindmap_test.go
+++ b/internal/mindmap/mindmap_test.go
@@ -71,6 +71,23 @@ func TestCreateMindMap(t *testing.T) {
 		panic(err)
 	}
 
+	dataTest3 := `{
+		"com": {
+			"google.com": {
+				"www.google.com": {}
+			},
+			"host.com": {
+				"www.host.com": {}
+			}
+		}
+	}`
+
+	var treeTest3 Node
+	err = json.Unmarshal([]byte(dataTest3), &treeTest3)
+	if err != nil {
+		panic(err)
+	}
+
 	tests := []struct {
 		name          string
 		args          args
@@ -149,6 +166,35 @@ func TestCreateMindMap(t *testing.T) {
 			},
 			want:    nil,
 			wantErr: true,
+		},
+		{
+			name: "Test 3: Correctly parsing domains that contain paths",
+			args: args{
+				source: scannerMock,
+			},
+			readLinesFunc: func() <-chan LineResult {
+				linesCh := make(chan LineResult)
+
+				go func() {
+					defer close(linesCh)
+
+					lines := []string{
+						"www.host.com/path1",
+						"www.host.com/path2",
+						"www.host.com/path3",
+						"www.google.com",
+					}
+
+					for _, line := range lines {
+						linesCh <- LineResult{Line: line}
+					}
+
+				}()
+
+				return linesCh
+			},
+			want:    treeTest3,
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
- Provided filename flag takes priority over data passed via pipe
- Correctly parse hostnames from urls that include protocol and path

fixex: https://github.com/Alevsk/rmm/issues/1